### PR TITLE
[#163232639] Allow to set configuration options per request

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ DPDApi::RequestHandler.request(:store_orders, attrs)
 DPDApi::RequestHandler.request(:get_tracking_data, tracking_number: "123456789")
 ```
 
+### Per request configuration
+```ruby
+DPDApi::RequestHandler.request(:get_auth) do |config|
+  config.username = ""
+  config.password = ""
+  config.sandbox = true
+end
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/dpd_api/request_handler.rb
+++ b/lib/dpd_api/request_handler.rb
@@ -9,6 +9,7 @@ module DPDApi
     def initialize(request_name, attrs)
       @request_name = request_name.to_sym
       @attrs = attrs
+      @config = Client.config.dup
     end
 
     def run
@@ -39,7 +40,7 @@ module DPDApi
     end
 
     private
-    attr_accessor :request_name, :attrs
+    attr_accessor :request_name, :attrs, :config
 
     def get_response
       xml = xml_builder(request.xml_attributes).build
@@ -81,10 +82,6 @@ module DPDApi
         username: config.username,
         password: config.password,
       }
-    end
-
-    def config
-      @config ||= Client.config
     end
   end
 end

--- a/lib/dpd_api/request_handler.rb
+++ b/lib/dpd_api/request_handler.rb
@@ -1,8 +1,8 @@
 module DPDApi
   class RequestHandler
     class << self
-      def request(request_name, attrs = {})
-        new(request_name, attrs).run
+      def request(request_name, attrs = {}, &block)
+        new(request_name, attrs).run(&block)
       end
     end
 
@@ -12,6 +12,7 @@ module DPDApi
     end
 
     def run
+      yield config if block_given?
       response = parse_response(get_response)
       if response.success?
         response

--- a/lib/dpd_api/version.rb
+++ b/lib/dpd_api/version.rb
@@ -1,3 +1,3 @@
 module DPDApi
-  VERSION = "0.0.10"
+  VERSION = "0.1.0"
 end

--- a/lib/dpd_api/version.rb
+++ b/lib/dpd_api/version.rb
@@ -1,3 +1,3 @@
 module DPDApi
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -16,16 +16,18 @@ describe DPDApi::RequestHandler do
   end
 
   context "with per request configuration" do
-    DPDApi::Client.configure do |config|
-      config.username = "sandboxdpd"
-      config.password = "wrongpassword"
-    end
-
     it "accepts new configuration options" do
-      VCR.use_cassette('get_auth') do
+      VCR.use_cassette('different_configuration') do
+        DPDApi::Client.configure do |config|
+          config.username = ENV['DPD_USERNAME']
+          config.password = "wrongpassword"
+          config.sandbox = true
+        end
+
         response = described_class.request(:get_auth) do |config|
           config.username = ENV['DPD_USERNAME']
           config.password = ENV['DPD_PASSWORD']
+          config.sandbox = true
         end
         expect(response.token).to eq("LTI5MzMzODEyNzE4OTY4MzY1NTARMTUzMzc3OTUyMjU2MwRR")
       end

--- a/spec/request_handler_spec.rb
+++ b/spec/request_handler_spec.rb
@@ -15,6 +15,23 @@ describe DPDApi::RequestHandler do
     end
   end
 
+  context "with per request configuration" do
+    DPDApi::Client.configure do |config|
+      config.username = "sandboxdpd"
+      config.password = "wrongpassword"
+    end
+
+    it "accepts new configuration options" do
+      VCR.use_cassette('get_auth') do
+        response = described_class.request(:get_auth) do |config|
+          config.username = ENV['DPD_USERNAME']
+          config.password = ENV['DPD_PASSWORD']
+        end
+        expect(response.token).to eq("LTI5MzMzODEyNzE4OTY4MzY1NTARMTUzMzc3OTUyMjU2MwRR")
+      end
+    end
+  end
+
   context "get_auth" do
     it "fetches auth token" do
       VCR.use_cassette('get_auth') do

--- a/spec/support/fixtures/vcr_cassettes/different_configuration.yml
+++ b/spec/support/fixtures/vcr_cassettes/different_configuration.yml
@@ -1,0 +1,54 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://public-ws-stage.dpd.com/services/LoginService/V2_0/
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8" standalone="no"?>
+        <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ns="http://dpd.com/common/service/types/LoginService/2.0">
+          <soapenv:Header/>
+          <soapenv:Body>
+            <ns:getAuth>
+              <delisId><USERNAME></delisId>
+              <password><PASSWORD></password>
+              <messageLanguage>en_EN</messageLanguage>
+            </ns:getAuth>
+          </soapenv:Body>
+        </soapenv:Envelope>
+    headers:
+      User-Agent:
+      - HTTPClient/1.0 (2.8.3, ruby 2.5.1 (2018-03-29))
+      Accept:
+      - "*/*"
+      Date:
+      - Mon, 21 Jan 2019 17:43:32 GMT
+      Soapaction:
+      - '"http://dpd.com/common/service/LoginService/2.0/getAuth"'
+      Content-Type:
+      - text/xml;charset=UTF-8
+      Content-Length:
+      - '424'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 21 Jan 2019 17:43:32 GMT
+      Server:
+      - Jetty(6.1.x)
+      Content-Type:
+      - text/xml; charset=utf-8
+      Vary:
+      - Accept-Encoding
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><ns2:getAuthResponse
+        xmlns:ns2="http://dpd.com/common/service/types/LoginService/2.0" xmlns:ns3="http://dpd.com/common/service/exceptions"><return><delisId><USERNAME></delisId><customerUid><USERNAME></customerUid><authToken>LTI5MzMzODEyNzE4OTY4MzY1NTARMTUzMzc3OTUyMjU2MwRR</authToken><depot>0998</depot></return></ns2:getAuthResponse></soap:Body></soap:Envelope>
+    http_version: 
+  recorded_at: Mon, 21 Jan 2019 17:43:32 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
We want to allow us change configuration options per request:

```
DPDApi::RequestHandler.request(:get_auth) do |config|
  config.username = ENV['DPD_USERNAME']
  config.password = ENV['DPD_PASSWORD']
  config.sandbox = true
end
```