### PR TITLE
Change the parameter order for the proactiveNotification

### DIFF
--- a/lib/xml/store_orders.xml.erb
+++ b/lib/xml/store_orders.xml.erb
@@ -66,10 +66,10 @@
               <proactiveNotification>
                 <channel><%= notification_channel %></channel>
                 <value><%= notification_value %></value>
-                <language><%= notification_locale %></language>
                 <% if notification_rule %>
                   <rule><%= notification_rule %></rule>
                 <% end %>
+                <language><%= notification_locale %></language>
               </proactiveNotification>
             <% else %>
               <% if food == 1 %>


### PR DESCRIPTION
The parameters/children of the proactiveNotification tag need to be in order for it to work.
Switch the language and rule fields order.